### PR TITLE
Allow ordering of pre/post expressions

### DIFF
--- a/attribute.ts
+++ b/attribute.ts
@@ -1,15 +1,25 @@
 import { action } from "mobx";
 
-import { Actor, Stat, StatExpression } from "./internal";
+import { Actor, Stat, ExpressionOptions } from "./internal";
 
 export class Attribute extends Stat {
   constructor(
     name: string,
     actor: Actor,
     baseValue: number = 1,
-    expressions: StatExpression<Attribute>[] = []
+    expressionOptions: ExpressionOptions<Attribute> = {}
   ) {
-    super(name, actor, expressions.concat(Attribute.defaultExpressions));
+    super(name, actor, {
+      preExpressions: (expressionOptions.preExpressions || []).concat(
+        Attribute.defaultOptions.preExpressions
+      ),
+      expressions: (expressionOptions.expressions || []).concat(
+        Attribute.defaultOptions.expressions
+      ),
+      postExpressions: (expressionOptions.postExpressions || []).concat(
+        Attribute.defaultOptions.postExpressions
+      )
+    });
     this.setBaseValue(baseValue);
   }
 
@@ -17,12 +27,16 @@ export class Attribute extends Stat {
 
   @action setBaseValue = (value) => (this.baseValue = value);
 
-  static get defaultExpressions(): StatExpression<Attribute>[] {
-    return [
-      // Floor
-      (value: number, _) => Math.floor(value),
-      // Clamp to 1
-      (value: number, _) => Math.max(value, 1)
-    ];
+  static get defaultOptions(): ExpressionOptions<Attribute> {
+    return {
+      preExpressions: [],
+      expressions: [],
+      postExpressions: [
+        // Floor
+        (value: number, _) => Math.floor(value),
+        // Clamp to 1
+        (value: number, _) => Math.max(value, 1)
+      ]
+    };
   }
 }

--- a/derivative.ts
+++ b/derivative.ts
@@ -1,10 +1,10 @@
-import { Stat, StatExpression } from "./internal";
+import { Stat, ExpressionOptions } from "./internal";
 
 export class Derivative extends Stat {
   constructor(
     name: string,
     actor,
-    expressions: StatExpression<Derivative>[] = []
+    expressions: ExpressionOptions<Derivative> = {}
   ) {
     super(name, actor, expressions);
   }

--- a/index.ts
+++ b/index.ts
@@ -99,7 +99,27 @@ console.log("Equipping cursed Encumbrance ring");
 person.equipItem({
   type: "accessory",
   sideEffects: {
-    passives: [{ property: "armorEncumbrance", value: 2.0, type: "factor" }]
+    passives: [
+      { property: "armorEncumbrance", value: 2.0, type: "factor" },
+      { property: "weaponEncumbrance", value: 2.0, type: "factor" }
+    ]
+  }
+});
+
+console.log("###########################################");
+console.log("Equipping Havel's ring");
+
+// There was a bug with the ordering of expressions.
+// Previously, weaponEfficiency was able to exceed 1
+// Fixed by adding the ability to pass pre/post expressions
+// to the base Stat class
+// Order:
+// child pre expressions -> Stat pre expressions => child expressions => Stat post expressions => child post expressions
+
+person.equipItem({
+  type: "accessory",
+  sideEffects: {
+    passives: [{ property: "weaponEfficiency", value: 3.0, type: "factor" }]
   }
 });
 

--- a/stat.ts
+++ b/stat.ts
@@ -5,12 +5,16 @@ export abstract class Stat {
   constructor(
     public readonly name: string, // keyof Stats (?)
     public actor: Actor,
-    public readonly expressions: StatExpression[]
+    expressionOptions: ExpressionOptions = {}
   ) {
-    this.expressions = Stat.preExpressions
-      .concat(this.expressions)
-      .concat(Stat.postExpressions);
+    this.expressions = (expressionOptions.preExpressions || [])
+      .concat(Stat.preExpressions)
+      .concat(expressionOptions.expressions || [])
+      .concat(Stat.postExpressions)
+      .concat(expressionOptions.postExpressions || []);
   }
+
+  public readonly expressions: StatExpression[];
 
   @observable baseValue = 0;
 
@@ -56,3 +60,9 @@ export type StatExpression<StatContext extends Stat = any> = (
   value: number,
   context: StatContext
 ) => number;
+
+export type ExpressionOptions<StatContext extends Stat = any> = {
+  preExpressions?: StatExpression<StatContext>[];
+  expressions?: StatExpression<StatContext>[];
+  postExpressions?: StatExpression<StatContext>[];
+};


### PR DESCRIPTION
This fixed a bug where expressions meant to run last, such as clamping expressions, or ceil/floor expressions, were not able to run after the passive stat modifier expressions for terms and factors